### PR TITLE
Added client_secret validation in refresh_token request.

### DIFF
--- a/identity-oidc-js/src/actions/sign-in.ts
+++ b/identity-oidc-js/src/actions/sign-in.ts
@@ -263,6 +263,10 @@ export const sendRefreshTokenRequest = (
     body.push(`refresh_token=${refreshToken}`);
     body.push("grant_type=refresh_token");
 
+    if (requestParams.clientSecret && requestParams.clientSecret.trim().length > 0) {
+        body.push(`client_secret=${requestParams.clientSecret}`);
+    }
+
     return axios.post(tokenEndpoint, body.join("&"), getTokenRequestHeaders(requestParams.clientHost))
         .then((response) => {
             if (response.status !== 200) {


### PR DESCRIPTION
Some auth server requires client_secret in get token request but in the refresh token as well.

## Purpose
Avoid the 401 Unauthorized responses in refresh token requests.

## Goals
Allowing send the client_secret param in refresh token requests.

## Approach
I just validate and take the clientSecret from the requestParams config and put it into body in refresh token requests.

## Release note
Allowed authentication with client secret configuration in refresh token requests.

## Documentation
N/A

## Automation tests
There are no test coverage in the project.

## Samples
import { IdentityAuth, SignInUtil } from "@wso2/identity-oidc-js";

const authConfig = {
    "clientHost": "<client-host>",
    "clientID": "<client-id>",
    "clientSecret": "<client-secret>",
    "loginCallbackURL": "<login-call-back-url>",
    "logoutCallbackURL": "<logout-call-back-url>",
    "serverOrigin": "<oauth-server>"
};
const authClient = new IdentityAuth(authConfig);
authClient.signIn().then(response => {
     const requestParams = JSON.parse(sessionStorage.getItem('request_params'));
     const refreshToken = sessionStorage.getItem('refresh_token');
     SignInUtil.sendRefreshTokenRequest(requestParams, refreshToken).then(response => console.log(response));
});