### PR TITLE
Added get access token method to client from session utils.

### DIFF
--- a/identity-oidc-js/src/client.ts
+++ b/identity-oidc-js/src/client.ts
@@ -18,6 +18,7 @@
 
 import { handleSignIn } from "./actions/sign-in";
 import { handleSignOut } from "./actions/sign-out";
+import { getAccessToken } from "./actions/session";
 import * as AUTHENTICATION_TYPES from "./constants";
 import { ConfigInterface } from "./models/client";
 
@@ -91,9 +92,14 @@ export class IdentityAuth {
         return;
     }
 
+    /**
+     * Get access token method.
+     *
+     * @returns {Promise<string>} promise.
+     * @memberof IdentityAuth
+     */
     public getAccessToken() {
-        // TODO: Implement
-        return;
+        return getAccessToken();
     }
 
     /**


### PR DESCRIPTION
## Purpose
To Have the get access token functionality directly in the client.

## Goals
Obtain the access token easily from the client.

## Release note
Get access token from the auth client easily.

## Documentation
There are no documentation about this part.

## Automation tests
There are no test coverage in the project.

## Samples
import { IdentityAuth } from "@wso2/identity-oidc-js";

const authClient = new IdentityAuth(configObject);
authClient.signIn().then(response => authClient.getAccessToken().then(token => { }));